### PR TITLE
export DBError in the DbTypes namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare namespace DbTypes {
 
   export {
     wrapError,
-
+    DBError,
     CheckViolationError,
     ConstraintViolationError,
     DataError,


### PR DESCRIPTION
[`objection-db-errors`](https://github.com/Vincit/objection-db-errors/blob/master/index.d.ts#L5) needs the `DBError` export to compile with TypeScript.  See the error below.
```
RobertStJohn:abc-server stjohnr> npm run tsc

> abc-server@1.0.0 tsc /Users/stjohnr/sandbox/abc-server
> tsc

node_modules/objection-db-errors/index.d.ts:5:3 - error TS2305: Module '"../../../../../../Users/stjohnr/sandbox/abc-server/node_modules/db-errors"' has no exported member 'DBError'.

5   DBError,
    ~~~~~~~
```