### PR TITLE
allow passing in db manually

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ declare namespace DbTypes {
     schema?: string;
   }
 
-  function wrapError(err: Error): DBError
+  function wrapError(err: Error, db?: string): DBError
 
   export {
     wrapError,

--- a/lib/dbErrors.js
+++ b/lib/dbErrors.js
@@ -8,15 +8,24 @@ const UniqueViolationError = require('./errors/UniqueViolationError');
 const CheckViolationError = require('./errors/CheckViolationError');
 const DataError = require('./errors/DataError');
 
-function wrapError(err) {
-  const dbs = Object.keys(parsers);
+const dbs = Object.keys(parsers);
 
-  for (let i = 0, l = dbs.length; i < l; ++i) {
-    const parserTree = parsers[dbs[i]];
+function wrapError(err, db) {
+  if (db) {
+    const parserTree = parsers[db];
     const result = parse(parserTree, err, null);
 
     if (result !== null) {
       return new result.node.error(result.args);
+    }
+  } else {
+    for (let i = 0; i < dbs.length; ++i) {
+      const parserTree = parsers[dbs[i]];
+      const result = parse(parserTree, err, null);
+  
+      if (result !== null) {
+        return new result.node.error(result.args);
+      }
     }
   }
 


### PR DESCRIPTION
Just a quick dirty hack to allow users to pass in the `db` manually (nothing else is changed). Most notably, this opens up the possibility for `objection-db-errors` to pass in the `db` during the wrapping process here: 

https://github.com/Vincit/objection-db-errors/blob/master/index.js#L9

'cause as it is right now, you need to check up to all 4 `db` types (mssql/sqlite/pg/mysql) _every time_ you want to wrap an error, and that's inefficient