### PR TITLE
Add constructor types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,24 @@
 declare namespace DbTypes {
 
+  interface DBErrorArgs {
+    nativeError: Error;
+    client: 'postgres' | 'mysql' | 'mssql' | 'sqlite';
+  }
+
   class DBError extends Error {
+    constructor(args: DBErrorArgs);
     name: string;
     nativeError: Error;
+    client: 'postgres' | 'mysql' | 'mssql' | 'sqlite';
+  }
+
+  interface CheckViolationErrorArgs extends DBErrorArgs {
+    table: string;
+    constraint: string;
   }
 
   class CheckViolationError extends DBError {
+    constructor(args: CheckViolationErrorArgs);
     table: string;
     constraint: string;
   }
@@ -14,20 +27,43 @@ declare namespace DbTypes {
 
   class DataError extends DBError {}
 
+  interface ForeignKeyViolationErrorArgs extends DBErrorArgs {
+    constructor(args: ForeignKeyViolationErrorArgs);
+    table: string;
+    constraint: string;
+    schema?: string;
+  }
+
   class ForeignKeyViolationError extends ConstraintViolationError {
     table: string;
     constraint: string;
     schema?: string;
   }
 
-  class NotNullViolationError extends ConstraintViolationError {
+  interface NotNullViolationErrorArgs extends DBErrorArgs {
     table: string;
     column: string;
+    schema?: string;
     database?: string;
+  }
+
+  class NotNullViolationError extends ConstraintViolationError {
+    constructor(args: NotNullViolationErrorArgs);
+    table: string;
+    column: string;
+    schema?: string;
+    database?: string;
+  }
+
+  interface UniqueViolationErrorArgs extends DBErrorArgs {
+    table: string;
+    columns: string[];
+    constraint: string;
     schema?: string;
   }
 
   class UniqueViolationError extends ConstraintViolationError {
+    constructor(args: UniqueViolationErrorArgs);
     table: string;
     columns: string[];
     constraint: string;


### PR DESCRIPTION
Trying to instantiate these error classes in TypeScript yielded a warning, since there was no constructor types, it was falling back to the default `Error` constructor (expecting a single `message` string argument).

Disclaimer: there might be a better way to implement this without all the duplication, but that would require more TypeScript skills than I currently possess.