### PR TITLE
fixes failing mssql tests

### DIFF
--- a/lib/errorCodes/mssql.js
+++ b/lib/errorCodes/mssql.js
@@ -3,7 +3,7 @@
 // select * from sysmessages where [error] in (2601, 2627, 515, 547, 241, 242, 8152, 245) and msglangid = 1033;
 
 const codes = {
-  16: new Set([241, 242, 245, 515, 547, 8152, 50000]),
+  16: new Set([241, 242, 245, 515, 547, 2628, 8152, 50000]),
   14: new Set([2601, 2627]),
 };
 

--- a/lib/parsers/mssql/DBError/DataError/parser.js
+++ b/lib/parsers/mssql/DBError/DataError/parser.js
@@ -8,11 +8,13 @@ module.exports = {
     // 241 - Conversion failed when converting date and/or time from character string.
     // 242 - The conversion of a nvarchar data type to a datetime data type resulted in an out-of-range value.
     // 245 - Conversion failed when converting the nvarchar value 'lol' to data type int.
+    // 2628 - String or binary data would be truncated.
     // 8152 - String or binary data would be truncated.
     if (
       isCode(err, 16, 241) ||
       isCode(err, 16, 242) ||
       isCode(err, 16, 245) ||
+      isCode(err, 16, 2628) ||
       isCode(err, 16, 8152)
     ) {
       return {};

--- a/tests/UniqueViolationError.js
+++ b/tests/UniqueViolationError.js
@@ -49,7 +49,7 @@ module.exports = (session) => {
 
             if (session.isMssql()) {
               expect(error.table).to.equal(table);
-              expect(error.constraint).to.equal('thetable_uniquepart1_uniquepart2_unique');
+              expect(error.constraint).to.equal('thetable_i_am_unique_col_unique');
             }
           });
       });
@@ -122,7 +122,7 @@ module.exports = (session) => {
             if (session.isMssql()) {
               expect(error.schema).to.equal('dbo');
               expect(error.table).to.equal(table);
-              expect(error.constraint).to.equal('thetable_uniquepart1_uniquepart2_unique');
+              expect(error.constraint).to.equal('thetable_i_am_unique_col_unique');
             }
           });
       });
@@ -159,7 +159,7 @@ module.exports = (session) => {
             if (session.isMssql()) {
               expect(error.schema).to.equal('dbo');
               expect(error.table).to.equal(table);
-              expect(error.constraint).to.equal('thetable_uniquepart1_uniquepart2_unique');
+              expect(error.constraint).to.equal('thetable_i_am_unique_col_unique');
             }
           });
       });


### PR DESCRIPTION
I've looked into the failing mssql tests and found that three tests simply expected the wrong value (I think) and one error code (2628) was missing.

I'm not sure why mssql uses multiple error codes for seemingly the same error but I'm also no mssql expert. Removing 8152 does not break the tests, so it might be obsolete?

Anyway, with those changes `npm run test:ci` passes locally.

