### PR TITLE
TypeError: Cannot read properties of undefined (reading 'length')

### DIFF
--- a/lib/parsers/mysql/DBError/parser.js
+++ b/lib/parsers/mysql/DBError/parser.js
@@ -9,7 +9,7 @@ module.exports = {
       typeof err.code === 'string' &&
       typeof err.sqlMessage === 'string' &&
       typeof err.sqlState === 'string' &&
-      err.sqlState.length === 5 &&
+      err.sqlState?.length === 5 &&
       errorCodes.has(err.code) &&
       typeof err.errno === 'number'
     ) {


### PR DESCRIPTION


TypeError: Cannot read properties of undefined (reading 'length')
    at Object.parse (node_modules/db-errors/lib/parsers/mysql/DBError/parser.js:11:23)
    at parse (node_modules/db-errors/lib/dbErrors.js:27:21)
    at wrapError (node_modules/db-errors/lib/dbErrors.js:16:20)
    at handleExecuteError (node_modules/objection/lib/queryBuilder/QueryBuilder.js:1140:32)
    at QueryBuilder.execute (node_modules/objection/lib/queryBuilder/QueryBuilder.js:449:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

On Fixing 
Error: ER_CON_COUNT_ERROR: Too many connections